### PR TITLE
Only add Service Desk properties if is_internal is set

### DIFF
--- a/jira/client.py
+++ b/jira/client.py
@@ -974,8 +974,15 @@ class JIRA(object):
         """
         data = {
             'body': body,
-            'properties':[{'key':'sd.public.comment','value':{'internal':is_internal}},]
         }
+
+        if is_internal:
+            data.update({
+                'properties': [
+                    {'key': 'sd.public.comment',
+                     'value': {'internal': is_internal}}
+                ]
+            })
 
         if visibility is not None:
             data['visibility'] = visibility


### PR DESCRIPTION
I saw that your earlier PR was closed. I'm working on adding JIRA Service Desk support and I needed this feature so I updated your branch to only set that Service Desk property when is_internal is set.